### PR TITLE
Fix for HumanPlayable environment using ale_py > 0.9.0

### DIFF
--- a/hackatari/core.py
+++ b/hackatari/core.py
@@ -230,6 +230,7 @@ class HumanPlayable(HackAtari):
         """
         kwargs["render_mode"] = "human"
         kwargs["render_oc_overlay"] = True
+        kwargs["full_action_space"] = True
         super(HumanPlayable, self).__init__(game, modifs, switch_modfis, switch_frame, rewardfunc_path, colorswaps, mode, difficulty, *args, **kwargs)
         self.reset()
         self.render()  # Initialize the pygame video system


### PR DESCRIPTION
`ale_py 0.9.1` introduces a change in `get_keys_to_action()`, which now maps the input keys to `Actions` instead of indices, which in turn only hold the action index of the full action space.

This breaks the current implementation that expects action-indices and passes them along to the environment, resulting in a `IndexError: list index out of range` when playing in environments that do not consist of all possible actions.

My fix simply enables the full action space in the environment, fixing the indexing. To the best of my knowledge, this does not break anything for the human play, as the games seem to simply ignore any actions that are not possible in the given game.