### PR TITLE
repair HackAtari constructor

### DIFF
--- a/hackatari/core.py
+++ b/hackatari/core.py
@@ -19,7 +19,7 @@ class HackAtari(OCAtari):
     HackAtari provides variation of Atari Learning Environments. 
     It is built on top of OCAtari, which provides object-centric observations.
     """
-    def __init__(self, env_name: str, modifs=[], switch_modfis=[], switch_frame=1000, obs_mode="dqn", rewardfunc_path=None, colorswaps=None, game_mode=0, difficulty=0, *args, **kwargs):
+    def __init__(self, env_name: str, modifs=[], switch_modfis=[], switch_frame=1000, rewardfunc_path=None, colorswaps=None, game_mode=0, difficulty=0, obs_mode="dqn", *args, **kwargs):
         """
         Initialize the game environment.
         """


### PR DESCRIPTION
Commit 9d961749f94211b3d7ce01911dfe3521dc653255 breaks the HackAtari constructor by emplacing `obs_mode` in the middle of the defined arguments instead of at the end.