### PR TITLE
Fix for rem_gui

### DIFF
--- a/hackatari/core.py
+++ b/hackatari/core.py
@@ -265,11 +265,10 @@ class HackAtari(OCAtari):
         return obs, info
 
     def render(self, image=None):
-
         if self.dopamine_pooling:
-            super().render(self._state_buffer_rgb[-1])
+            return super().render(self._state_buffer_rgb[-1])
         else:
-            super().render()
+            return super().render()
 
     # def _colorswap_step(self, *args, **kwargs):
     #     """


### PR DESCRIPTION
The __init__ of the `rem_gui` Renderer relies on getting an initial frame to gauge the window size 
https://github.com/k4ntz/HackAtari/blob/a234a312d3712b8f827057a6bb4af9bccc814abe/scripts/rem_gui.py#L60-L61
For this, the render method should return the rendered frame. This behavior is broken in a234a31.

The fix works by returning the rendering result.